### PR TITLE
change np.float() to float() to avoid python warning after numpy deprecation

### DIFF
--- a/03-Constant-Quasi-Constant-Duplicates/03.2-Quasi-constant-features.ipynb
+++ b/03-Constant-Quasi-Constant-Duplicates/03.2-Quasi-constant-features.ipynb
@@ -270,15 +270,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-9-d5ad38f371c4>:4: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.\n",
-      "Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations\n",
-      "  X_train['var_1'].value_counts() / np.float(len(X_train))\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "0    0.999629\n",
@@ -297,7 +288,7 @@
     "# percentage of observations showing each of the different values\n",
     "# of the variable\n",
     "\n",
-    "X_train['var_1'].value_counts() / np.float(len(X_train))"
+    "X_train['var_1'].value_counts() / float(len(X_train))"
    ]
   },
   {
@@ -312,15 +303,6 @@
    "execution_count": 10,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-10-e7a55defe18a>:3: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.\n",
-      "Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations\n",
-      "  X_train['var_2'].value_counts() / np.float(len(X_train))\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -337,7 +319,7 @@
    "source": [
     "# let's explore another one\n",
     "\n",
-    "X_train['var_2'].value_counts() / np.float(len(X_train))"
+    "X_train['var_2'].value_counts() / float(len(X_train))"
    ]
   },
   {

--- a/03-Constant-Quasi-Constant-Duplicates/03.3-Duplicated-features.ipynb
+++ b/03-Constant-Quasi-Constant-Duplicates/03.3-Duplicated-features.ipynb
@@ -155,7 +155,7 @@
     "\n",
     "    # find the predominant value, that is the value that is shared\n",
     "    # by most observations\n",
-    "    predominant = (X_train[feature].value_counts() / np.float(\n",
+    "    predominant = (X_train[feature].value_counts() / float(\n",
     "        len(X_train))).sort_values(ascending=False).values[0]\n",
     "\n",
     "    # evaluate predominant feature: do more than 99% of the observations\n",


### PR DESCRIPTION
np.float() gives AttributeError

AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations